### PR TITLE
Parse and TryParse behavior fixes

### DIFF
--- a/src/SemanticVersion/SemanticVersion.cs
+++ b/src/SemanticVersion/SemanticVersion.cs
@@ -126,15 +126,19 @@
         /// <summary>Parses the specified string to a semantic version.</summary>
         /// <param name="versionString">The version string.</param>
         /// <returns>A new <see cref="SemanticVersion"/> object that has the specified values.</returns>
+        /// <exception cref="ArgumentNullException">Raised when the input string is null.</exception>
         /// <exception cref="ArgumentException">Raised when the the whole version string is in an invalid format.</exception>
         /// <exception cref="InvalidOperationException">Raised when some part of the version string has an invalid format.</exception>
         public static SemanticVersion Parse(string versionString)
         {
+            if (versionString == null)
+                throw new ArgumentNullException(nameof(versionString));
+
             SemanticVersion version;
+
             if (!TryParse(versionString, out version))
-            {
-                throw new ArgumentException("The provided version string is invalid", nameof(versionString));
-            }
+                throw new ArgumentException("The provided version string is invalid.", nameof(versionString));
+
             return version;
         }
 
@@ -146,13 +150,15 @@
         /// <returns><c>False</c> when a invalid version string is passed, otherwise <c>true</c>.</returns>
         public static bool TryParse(string versionString, out SemanticVersion version)
         {
+            version = null;
+
+            if (versionString == null)
+                return false;
+
             Match versionMatch = VersionExpression.Match(versionString);
 
             if (!versionMatch.Success)
-            {
-                version = null;
                 return false;
-            }
 
             // Parse the major component, if the match equals to "*",
             // we return a version that matches everty version.

--- a/test/SemanticVersionTest/SemanticVersion/ParseTests.cs
+++ b/test/SemanticVersionTest/SemanticVersion/ParseTests.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SemanticVersionTest
+﻿namespace SemanticVersionTest
 {
+    using System;
     using SemVersion;
-
     using Xunit;
 
     // This project can output the Class library as a NuGet Package.
@@ -61,6 +56,24 @@ namespace SemanticVersionTest
         public void ParseMajorWildcard()
         {
             var version = SemanticVersion.Parse("1.*");
+        }
+
+        [Fact]
+        public void ParseNullThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => SemanticVersion.Parse(null));
+        }
+
+        [Fact]
+        public void ParseEmptyStringThrows()
+        {
+            Assert.Throws<ArgumentException>(() => SemanticVersion.Parse(string.Empty));
+        }
+
+        [Fact]
+        public void ParseInvalidStringThrows()
+        {
+            Assert.Throws<ArgumentException>(() => SemanticVersion.Parse("invalid-version"));
         }
 
         [Fact]

--- a/test/SemanticVersionTest/SemanticVersion/TryParseTests.cs
+++ b/test/SemanticVersionTest/SemanticVersion/TryParseTests.cs
@@ -7,17 +7,53 @@ namespace SemanticVersionTest
     public class TryParseTests
     {
         [Fact]
-        public void Parse()
+        public void TryParseReturnsVersion()
         {
             SemanticVersion version;
-            Assert.True(SemanticVersion.TryParse("1.1.1", out version));
+            var result = SemanticVersion.TryParse("1.1.1", out version);
+
+            Assert.True(result);
+            Assert.Equal(new SemanticVersion(1, 1, 1), version);
         }
 
         [Fact]
-        public void ParseFail()
+        public void TryParseNullReturnsFalse()
         {
             SemanticVersion version;
-            Assert.False(SemanticVersion.TryParse("1", out version));
+            var result = SemanticVersion.TryParse(null, out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact]
+        public void TryParseEmptyStringReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse(string.Empty, out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact]
+        public void TryParseInvalidStringReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("invalid-version", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact]
+        public void TryParseNonStandardReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
         }
     }
 }


### PR DESCRIPTION
Additional test coverage and code fixes for exceptional cases when input string is null or empty:
- `TryParse` should return false if input string is null, _not throw_ exception
- Parse should _throw_ `ArgumentNullException` if input string is null (or consistency with System.Version and other standard Parse implementations)
