### PR TITLE
Fixes of failures on incomplete version string

### DIFF
--- a/test/SemanticVersionTest/SemanticVersion/ParseTests.cs
+++ b/test/SemanticVersionTest/SemanticVersion/ParseTests.cs
@@ -53,12 +53,6 @@
         }
 
         [Fact]
-        public void ParseMajorWildcard()
-        {
-            var version = SemanticVersion.Parse("1.*");
-        }
-
-        [Fact]
         public void ParseNullThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => SemanticVersion.Parse(null));
@@ -77,27 +71,21 @@
         }
 
         [Fact]
-        public void ParseFail()
+        public void ParseMissingMinorThrows()
         {
-            Assert.Throws<ArgumentException>(() => SemanticVersion.Parse("foo-1.232+1"));
+            Assert.Throws<ArgumentException>(() => SemanticVersion.Parse("1"));
         }
 
         [Fact]
-        public void ParseInvalidOperationNoMinorNoPatch()
+        public void ParseMissingPatchThrows()
         {
-            Assert.Throws<InvalidOperationException>(() => SemanticVersion.Parse("1"));
+            Assert.Throws<ArgumentException>(() => SemanticVersion.Parse("1.2"));
         }
 
         [Fact]
-        public void ParseInvalidOperationNoPatch()
+        public void ParseMissingPatchWithPrereleaseThrows()
         {
-            Assert.Throws<InvalidOperationException>(() => SemanticVersion.Parse("1.3"));
-        }
-
-        [Fact]
-        public void ParseInvalidOperationNoPatchWithPrerelease()
-        {
-            Assert.Throws<InvalidOperationException>(() => SemanticVersion.Parse("1.3-alpha"));
+            Assert.Throws<ArgumentException>(() => SemanticVersion.Parse("1.2-alpha"));
         }
 
         [Fact]
@@ -113,7 +101,7 @@
         [Fact]
         public void ImplicitConversionFail()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 SemanticVersion version = "1";
             });

--- a/test/SemanticVersionTest/SemanticVersion/TryParseTests.cs
+++ b/test/SemanticVersionTest/SemanticVersion/TryParseTests.cs
@@ -10,10 +10,10 @@ namespace SemanticVersionTest
         public void TryParseReturnsVersion()
         {
             SemanticVersion version;
-            var result = SemanticVersion.TryParse("1.1.1", out version);
+            var result = SemanticVersion.TryParse("1.2.3", out version);
 
             Assert.True(result);
-            Assert.Equal(new SemanticVersion(1, 1, 1), version);
+            Assert.Equal(new SemanticVersion(1, 2, 3), version);
         }
 
         [Fact]
@@ -47,10 +47,116 @@ namespace SemanticVersionTest
         }
 
         [Fact]
-        public void TryParseNonStandardReturnsFalse()
+        public void TryParseMissingMinorReturnsFalse()
         {
             SemanticVersion version;
             var result = SemanticVersion.TryParse("1", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact]
+        public void TryParseMissingPatchReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.2", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact]
+        public void TryParseMissingPatchWithPrereleaseReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.2-alpha", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact]
+        public void TryParseMajorWildcard()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("*", out version);
+
+            Assert.True(result);
+            Assert.Equal(null, version.Major);
+            Assert.Equal(null, version.Minor);
+            Assert.Equal(null, version.Patch);
+        }
+
+        [Fact]
+        public void TryParseMinorWildcard()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.*", out version);
+
+            Assert.True(result);
+            Assert.Equal(1, version.Major);
+            Assert.Equal(null, version.Minor);
+            Assert.Equal(null, version.Patch);
+        }
+
+        [Fact]
+        public void TryParsePatchWildcard()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.2.*", out version);
+
+            Assert.True(result);
+            Assert.Equal(1, version.Major);
+            Assert.Equal(2, version.Minor);
+            Assert.Equal(null, version.Patch);
+        }
+
+        [Fact(Skip = "Needs check with specification and regex refactoring")]
+        public void TryParseWildcardWithMinorReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("*.2", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact(Skip = "Needs check with specification and regex refactoring")]
+        public void TryParseWildcardWithMinorAndPatchReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("*.2.3", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact(Skip = "Needs check with specification and regex refactoring")]
+        public void TryParseWildcardInMiddleReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.*.3", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact(Skip = "Needs check with specification and regex refactoring")]
+        public void TryParseMinorWildcardWithPrereleaseReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.*-alpha", out version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Fact(Skip = "Needs check with specification and regex refactoring")]
+        public void TryParsePatchWildcardWithPrereleaseReturnsFalse()
+        {
+            SemanticVersion version;
+            var result = SemanticVersion.TryParse("1.2.*-alpha", out version);
 
             Assert.False(result);
             Assert.Null(version);


### PR DESCRIPTION
I added more tests and fixed regex matching in case of incomplete version strings (e.g. `1`, `1.2` etc.).
Also changed some existing tests to expect `ArgumentException`, not `InvalidOperationException`.

Plus, added tests to handle invalid placing of wildcards (e.g. `1.*.2` or `1.*-alpha`), but didn't manage to quickly fix it because it requires total review of the existing regular expression, so I kept them ignored for now.
