### PR TITLE
Fix #10 (pre-release comparisons), add several tests

### DIFF
--- a/src/SemanticVersion/SemanticVersionStringExtensions.cs
+++ b/src/SemanticVersion/SemanticVersionStringExtensions.cs
@@ -20,12 +20,12 @@ namespace SemVersion
 
             if (componentEmpty || component == "*")
             {
-                return -1;
+                return +1;
             }
 
             if (otherEmtpy || other == "*")
             {
-                return 1;
+                return -1;
             }
 
             string[] componentParts = component.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);

--- a/test/SemanticVersionTest/Comparer/CompareTests.cs
+++ b/test/SemanticVersionTest/Comparer/CompareTests.cs
@@ -44,5 +44,69 @@ namespace SemanticVersionTest.Comparer
 
             Assert.Equal(0, comparer.Compare(null, null));
         }
+
+        [Fact]
+        public void ComparePrereleaseRelease()
+        {
+            SemanticVersion left = new SemanticVersion(1, 0, 0, "beta");
+            SemanticVersion right = new SemanticVersion(1, 0, 0);
+
+            VersionComparer comparer = new VersionComparer();
+
+            // "When major, minor, and patch are equal, a pre-release
+            // version has lower precedence than a normal version."
+            Assert.Equal(-1, comparer.Compare(left, right));
+        }
+
+        [Fact]
+        public void ComparePrereleaseNumeric()
+        {
+            SemanticVersion left = new SemanticVersion(1, 0, 0, "alpha.23");
+            SemanticVersion right = new SemanticVersion(1, 0, 0, "alpha.5");
+
+            VersionComparer comparer = new VersionComparer();
+
+            // "identifiers consisting of only digits are compared numerically"
+            Assert.Equal(1, comparer.Compare(left, right));
+        }
+
+        [Fact]
+        public void ComparePrereleaseNonnumeric()
+        {
+            SemanticVersion left = new SemanticVersion(1, 0, 0, "42.alpha");
+            SemanticVersion right = new SemanticVersion(1, 0, 0, "42.beta");
+
+            VersionComparer comparer = new VersionComparer();
+
+            // "identifiers with letters or hyphens are compared lexically in ASCII sort order"
+            Assert.Equal(-1, comparer.Compare(left, right));
+        }
+
+        [Fact]
+        public void ComparePrereleaseNumericVsOther()
+        {
+            SemanticVersion left = new SemanticVersion(1, 0, 0, "alpha.1");
+            SemanticVersion right = new SemanticVersion(1, 0, 0, "alpha.beta");
+
+            VersionComparer comparer = new VersionComparer();
+
+            // "Numeric identifiers always have lower precedence than non-numeric identifiers."
+            // Meaning: "... precede ..." (as per the above example from the spec).
+            Assert.Equal(-1, comparer.Compare(left, right));
+        }
+
+        [Fact]
+        public void ComparePrereleaseFieldNumber()
+        {
+            SemanticVersion left = new SemanticVersion(1, 0, 0, "alpha");
+            SemanticVersion right = new SemanticVersion(1, 0, 0, "alpha.1");
+
+            VersionComparer comparer = new VersionComparer();
+
+            // "A larger set of pre-release fields has a higher
+            // precedence than a smaller set, if all of the preceding
+            // identifiers are equal."
+            Assert.Equal(-1, comparer.Compare(left, right));
+        }
     }
 }


### PR DESCRIPTION
Issue #10 reports a mixed up comparison for prerelease vs release.  This fixes #10 and adds some brute-force tests for prerelease comparisons, as per the specification.